### PR TITLE
Typesafe Config support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,8 @@ The goal is to have CNF-02 as an extension of CNF-01 with the added third party 
 
 CNF-01's interface converts to a String to String map of configurations. For this reason, Lists and Maps used in Typesafe Config are represented as Strings and might require parsing depending on the use case.
 
+Null values are not supported. Keys that have null values are not present in the resulting Map.
+
 == How to use
 
 // add instructions how people can start to use your project

--- a/README.adoc
+++ b/README.adoc
@@ -19,14 +19,24 @@ The goal is to have CNF-02 as an extension of CNF-01 with the added third party 
 
 == Limitations
 
-Features are still under development.
+CNF-01's interface converts to a String to String map of configurations. For this reason, Lists and Maps used in Typesafe Config are represented as Strings and might require parsing depending on the use case.
 
 == How to use
 
 // add instructions how people can start to use your project
 See https://github.com/teragrep/cnf_01[CNF-01's documentation] for using the library.
 
-Instructions for converting Typesafe Config will be written here when the functionality has been developed.
+Example for using `TypesafeConfiguration`:
+
+[,java]
+----
+// One way of initializing Typesafe Config
+Config config = ConfigFactory.parseFile("file/path");
+
+// Converting Config to CNF-01 Map.
+Configuration configuration = new TypesafeConfiguration(config);
+Map<String, String> configurationMap = configuration.asMap();
+----
 
 == Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,16 @@
     <sha1></sha1>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>com.teragrep</groupId>
+      <artifactId>cnf_01</artifactId>
+      <version>1.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>1.4.3</version>
+    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/src/main/java/com/teragrep/cnf_02/TypesafeConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_02/TypesafeConfiguration.java
@@ -1,0 +1,107 @@
+/*
+ * Teragrep Configuration Wrapper for Typesafe Config (cnf_02)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cnf_02;
+
+import com.teragrep.cnf_01.Configuration;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class TypesafeConfiguration implements Configuration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TypesafeConfiguration.class);
+
+    private final Config config;
+
+    public TypesafeConfiguration(final Config config) {
+        this.config = config;
+    }
+
+    @Override
+    public Map<String, String> asMap() {
+        // Convert the Config to a Map<String, String>
+        final Map<String, String> map = Collections
+                .unmodifiableMap(
+                        config
+                                .entrySet()
+                                .stream()
+                                .collect(
+                                        Collectors
+                                                .toMap(
+                                                        entry -> entry.getKey(),
+                                                        entry -> entry.getValue().unwrapped().toString()
+                                                )
+                                )
+                );
+
+        LOGGER.debug("Returning configuration map converted from a Typesafe Config.");
+        LOGGER.trace("Returning configuration map <[{}]>", map);
+
+        return map;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TypesafeConfiguration configuration = (TypesafeConfiguration) o;
+        return config.equals(configuration.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(config);
+    }
+}

--- a/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,12 @@ public class TypesafeConfigurationTest {
         TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
         Map<String, String> map = cnf.asMap();
 
+        // assert the original typesafe config
+        Assertions.assertEquals(3, typesafe.entrySet().size());
+        Assertions.assertEquals(1, typesafe.getInt("foo"));
+        Assertions.assertEquals("foo", typesafe.getString("bar"));
+        Assertions.assertTrue(typesafe.getBoolean("fizz"));
+        // assert the resulting map
         Assertions.assertEquals(3, map.size());
         Assertions.assertEquals("1", map.get("foo"));
         Assertions.assertEquals("foo", map.get("bar"));
@@ -90,6 +97,11 @@ public class TypesafeConfigurationTest {
 
         Map<String, String> map = cnf.asMap();
 
+        // assert the original typesafe config
+        Assertions.assertEquals(0, typesafe.entrySet().size()); // entrySet() doesn't return null values
+        Assertions.assertFalse(typesafe.isEmpty());
+        Assertions.assertTrue(typesafe.getIsNull("nullValue"));
+
         // null values are not returned from the typesafe config, list stays empty
         Assertions.assertEquals(0, map.size());
     }
@@ -105,6 +117,10 @@ public class TypesafeConfigurationTest {
         TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
 
         Map<String, String> map = cnf.asMap();
+
+        // assert the original typesafe config
+        Assertions.assertEquals(1, typesafe.entrySet().size());
+        Assertions.assertEquals(Arrays.asList("first", "second"), typesafe.getList("listValue").unwrapped());
 
         Assertions.assertEquals(1, map.size());
         Assertions.assertEquals("[first, second]", map.get("listValue"));
@@ -122,7 +138,11 @@ public class TypesafeConfigurationTest {
 
         Map<String, String> map = cnf.asMap();
 
-        // Map gets split to individual paths
+        // assert the original typesafe config
+        Assertions.assertEquals(2, typesafe.entrySet().size());
+        Assertions.assertEquals("foo", typesafe.getString("map.value.path.bar"));
+        Assertions.assertEquals("bar", typesafe.getString("map.value.path.foo"));
+        // assert the resulting map
         Assertions.assertEquals(2, map.size());
         Assertions.assertEquals("foo", map.get("map.value.path.bar"));
         Assertions.assertEquals("bar", map.get("map.value.path.foo"));
@@ -146,6 +166,10 @@ public class TypesafeConfigurationTest {
 
         Map<String, String> map = cnf.asMap();
 
+        // assert the original typesafe config
+        Assertions.assertEquals(1, typesafe.entrySet().size());
+        Assertions.assertEquals(Arrays.asList(input1, input2), typesafe.getList("list.value.path").unwrapped());
+        // assert the resulting map
         Assertions.assertEquals(1, map.size());
         // the keys are put in alphabetical order in the maps
         Assertions.assertEquals("[{bar=2, foo=1}, {bar=2, foo=1}]", map.get("list.value.path"));

--- a/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
@@ -1,0 +1,199 @@
+/*
+ * Teragrep Configuration Wrapper for Typesafe Config (cnf_02)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cnf_02;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TypesafeConfigurationTest {
+
+    @Test
+    public void testBasicValues() {
+        Config typesafe = ConfigFactory.parseFile(new File("src/test/resources/configuration.properties")); // typesafe config is immutable
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+        Map<String, String> map = cnf.asMap();
+
+        Assertions.assertEquals(3, map.size());
+        Assertions.assertEquals("1", map.get("foo"));
+        Assertions.assertEquals("foo", map.get("bar"));
+        Assertions.assertEquals("true", map.get("fizz"));
+    }
+
+    @Test
+    public void testEmptyConfiguration() {
+        Config typesafe = ConfigFactory.empty();
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+        Map<String, String> map = cnf.asMap();
+
+        Assertions.assertTrue(map.isEmpty());
+        Assertions.assertTrue(typesafe.isEmpty());
+    }
+
+    @Test
+    public void testNull() {
+        Config typesafe = ConfigFactory.empty();
+        typesafe = typesafe.withValue("nullValue", ConfigValueFactory.fromAnyRef(null));
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+
+        Map<String, String> map = cnf.asMap();
+
+        // null values are not returned from the typesafe config, list stays empty
+        Assertions.assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testList() {
+        List<String> list = new ArrayList<>();
+        list.add("first");
+        list.add("second");
+
+        Config typesafe = ConfigFactory.empty();
+        typesafe = typesafe.withValue("listValue", ConfigValueFactory.fromIterable(list));
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+
+        Map<String, String> map = cnf.asMap();
+
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertEquals("[first, second]", map.get("listValue"));
+    }
+
+    @Test
+    public void testMap() {
+        Map<String, String> input = new HashMap<>();
+        input.put("foo", "bar");
+        input.put("bar", "foo");
+
+        Config typesafe = ConfigFactory.empty();
+        typesafe = typesafe.withValue("map.value.path", ConfigValueFactory.fromMap(input));
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+
+        Map<String, String> map = cnf.asMap();
+
+        // Map gets split to individual paths
+        Assertions.assertEquals(2, map.size());
+        Assertions.assertEquals("foo", map.get("map.value.path.bar"));
+        Assertions.assertEquals("bar", map.get("map.value.path.foo"));
+    }
+
+    @Test
+    public void testMapsInList() {
+        Map<String, Object> input1 = new HashMap<>();
+        input1.put("foo", 1);
+        input1.put("bar", 2);
+        Map<String, Object> input2 = new HashMap<>();
+        input2.put("foo", 1);
+        input2.put("bar", 2);
+        List<Object> list = new ArrayList<>();
+        list.add(input1);
+        list.add(input2);
+
+        Config typesafe = ConfigFactory.empty();
+        typesafe = typesafe.withValue("list.value.path", ConfigValueFactory.fromIterable(list));
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+
+        Map<String, String> map = cnf.asMap();
+
+        Assertions.assertEquals(1, map.size());
+        // the keys are put in alphabetical order in the maps
+        Assertions.assertEquals("[{bar=2, foo=1}, {bar=2, foo=1}]", map.get("list.value.path"));
+    }
+
+    @Test
+    public void testImmutability() {
+        Config typesafe = ConfigFactory.empty();
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+        Map<String, String> map = cnf.asMap();
+
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> map.put("biz", "buz")); // immutable
+    }
+
+    @Test
+    public void testEquals() {
+        Config typesafe = ConfigFactory.parseFile(new File("src/test/resources/configuration.properties"));
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+        TypesafeConfiguration cnf2 = new TypesafeConfiguration(typesafe);
+
+        cnf.asMap();
+
+        Assertions.assertEquals(cnf, cnf2);
+    }
+
+    @Test
+    public void testNotEquals() {
+        Config typesafe = ConfigFactory.parseFile(new File("src/test/resources/configuration.properties"));
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+        TypesafeConfiguration cnf2 = new TypesafeConfiguration(typesafe.withoutPath("bar"));
+
+        Assertions.assertNotEquals(cnf, cnf2);
+    }
+
+    @Test
+    public void testHashCode() {
+        Config typesafe = ConfigFactory.parseFile(new File("src/test/resources/configuration.properties"));
+        Config typesafe2 = typesafe.withoutPath("bar");
+        TypesafeConfiguration cnf = new TypesafeConfiguration(typesafe);
+        TypesafeConfiguration cnf2 = new TypesafeConfiguration(typesafe);
+        TypesafeConfiguration cnf3 = new TypesafeConfiguration(typesafe2);
+
+        Assertions.assertEquals(cnf.hashCode(), cnf2.hashCode());
+        Assertions.assertNotEquals(cnf.hashCode(), cnf3.hashCode());
+    }
+
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier.forClass(TypesafeConfiguration.class).withNonnullFields("config").verify();
+    }
+}

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -1,0 +1,3 @@
+bar=foo
+fizz=true
+foo=1


### PR DESCRIPTION
Fixes #2 

Converts Typesafe Config to an immutable map using CNF-01 interface.

Typesafe supports some constructs that are difficult to convert to the Map<String, String>. With this solution:

- Lists are represented as "[value1, value2]"
- Maps are put to individual paths like "path.key1=value1, path.key2=value2" and so on.
- Nulls are not supported and the paths will not show up in the resulting Map.
- There are combinations like a list of maps: that would equal to a String like "[{key=value, key2=value2}, {key=value, key2=value2}]".

The behavior can be seen in the tests quite well too.

Otherwise, Typesafe Config is immutable! So there was no need to do any tricks in the constructor this time. Its immutability means that the configuration can't be changed in between the constructor call and calling `asMap()`.