### PR TITLE
Convert list configuration values to Json format

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,9 @@ The goal is to have CNF-02 as an extension of CNF-01 with the added third party 
 
 == Limitations
 
-CNF-01's interface converts to a String to String map of configurations. For this reason, Lists and Maps used in Typesafe Config are represented as Strings and might require parsing depending on the use case.
+CNF-01's interface converts to a String to String map of configurations. For this reason, Lists used in Typesafe Config are represented as Strings. The resulting List Strings are in Json format and can be parsed with Gson.
+
+Maps are represented individually as key-value pairs like in Typesafe Config.
 
 Null values are not supported. Keys that have null values are not present in the resulting Map.
 

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ The goal is to have CNF-02 as an extension of CNF-01 with the added third party 
 
 == Limitations
 
-CNF-01's interface converts to a String to String map of configurations. For this reason, Lists used in Typesafe Config are represented as Strings. The resulting List Strings are in Json format and can be parsed with Gson.
+CNF-01's interface converts to a String to String map of configurations. For this reason, Lists used in Typesafe Config are represented as Strings. The resulting List Strings are in Json format and can be parsed with Jakarta or Gson for example.
 
 Maps are represented individually as key-value pairs like in Typesafe Config.
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,14 @@
       <version>1.4.3</version>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.11.0</version>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+      <version>1.1.7</version>
     </dependency>
     <!-- Logging -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>config</artifactId>
       <version>1.4.3</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.11.0</version>
+    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/src/main/java/com/teragrep/cnf_02/TypesafeConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_02/TypesafeConfiguration.java
@@ -45,15 +45,17 @@
  */
 package com.teragrep.cnf_02;
 
-import com.google.gson.Gson;
 import com.teragrep.cnf_01.Configuration;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
 import com.typesafe.config.ConfigValueType;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -98,11 +100,13 @@ public final class TypesafeConfiguration implements Configuration {
      * @return the ConfigValue as a String
      */
     private String configValueAsString(final ConfigValue value) {
-        String valueAsJson = value.unwrapped().toString();
+        String valueString = value.unwrapped().toString();
         if (value.valueType().equals(ConfigValueType.LIST)) {
-            valueAsJson = new Gson().toJson(value.unwrapped());
+            final List<Object> list = (List<Object>) value.unwrapped(); // Typesafe returns List<Object> for ConfigValueType.LIST
+            final JsonArray arr = Json.createArrayBuilder(list).build();
+            valueString = arr.toString();
         }
-        return valueAsJson;
+        return valueString;
     }
 
     @Override

--- a/src/main/java/com/teragrep/cnf_02/TypesafeConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_02/TypesafeConfiguration.java
@@ -45,8 +45,11 @@
  */
 package com.teragrep.cnf_02;
 
+import com.google.gson.Gson;
 import com.teragrep.cnf_01.Configuration;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +80,7 @@ public final class TypesafeConfiguration implements Configuration {
                                         Collectors
                                                 .toMap(
                                                         entry -> entry.getKey(),
-                                                        entry -> entry.getValue().unwrapped().toString()
+                                                        entry -> configValueAsString(entry.getValue())
                                                 )
                                 )
                 );
@@ -86,6 +89,20 @@ public final class TypesafeConfiguration implements Configuration {
         LOGGER.trace("Returning configuration map <[{}]>", map);
 
         return map;
+    }
+
+    /**
+     * Returns the ConfigValue as a String. If a List is provided, returns it in Json format.
+     * 
+     * @param value in Config
+     * @return the ConfigValue as a String
+     */
+    private String configValueAsString(final ConfigValue value) {
+        String valueAsJson = value.unwrapped().toString();
+        if (value.valueType().equals(ConfigValueType.LIST)) {
+            valueAsJson = new Gson().toJson(value.unwrapped());
+        }
+        return valueAsJson;
     }
 
     @Override

--- a/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
@@ -45,16 +45,18 @@
  */
 package com.teragrep.cnf_02;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonReader;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -110,8 +112,6 @@ public class TypesafeConfigurationTest {
 
     @Test
     public void testList() {
-        TypeToken<List<String>> listType = new TypeToken<>() {
-        }; // for gson
         List<String> list = new ArrayList<>();
         list.add("first");
         list.add("second");
@@ -122,6 +122,14 @@ public class TypesafeConfigurationTest {
 
         Map<String, String> map = cnf.asMap();
 
+        // parse back into a java list
+        JsonReader reader = Json.createReader(new StringReader(map.get("listValue")));
+        JsonArray arr = reader.readArray();
+        List<String> parsedList = new ArrayList<>();
+        for (int i = 0; i < arr.size(); i++) {
+            parsedList.add(arr.getString(i));
+        }
+
         // assert the original typesafe config
         Assertions.assertEquals(1, typesafe.entrySet().size());
         Assertions.assertEquals(Arrays.asList("first", "second"), typesafe.getList("listValue").unwrapped());
@@ -129,8 +137,8 @@ public class TypesafeConfigurationTest {
         Assertions.assertEquals(1, map.size());
         Assertions.assertEquals("[\"first\",\"second\"]", map.get("listValue"));
 
-        // can be parsed with gson to the original list
-        Assertions.assertEquals(list, new Gson().fromJson(map.get("listValue"), listType));
+        // can be parsed with jakarta to the original list
+        Assertions.assertEquals(list, parsedList);
     }
 
     @Test
@@ -157,9 +165,6 @@ public class TypesafeConfigurationTest {
 
     @Test
     public void testMapsInList() {
-        TypeToken<List<Map<String, Integer>>> listType = new TypeToken<>() {
-        }; // for gson
-
         Map<String, Integer> input1 = new HashMap<>();
         input1.put("foo", 1);
         input1.put("bar", 2);
@@ -176,6 +181,18 @@ public class TypesafeConfigurationTest {
 
         Map<String, String> map = cnf.asMap();
 
+        // parse back into a java list
+        JsonReader reader = Json.createReader(new StringReader(map.get("list.value.path")));
+        JsonArray arr = reader.readArray();
+        List<Map<String, Integer>> parsedList = new ArrayList<>();
+        for (int i = 0; i < arr.size(); i++) {
+            Map<String, Integer> parsedMap = new HashMap<>();
+            for (Map.Entry entry : arr.getJsonObject(i).entrySet()) {
+                parsedMap.put(entry.getKey().toString(), Integer.parseInt(entry.getValue().toString()));
+            }
+            parsedList.add(parsedMap);
+        }
+
         // assert the original typesafe config
         Assertions.assertEquals(1, typesafe.entrySet().size());
         Assertions.assertEquals(Arrays.asList(input1, input2), typesafe.getList("list.value.path").unwrapped());
@@ -183,9 +200,8 @@ public class TypesafeConfigurationTest {
         Assertions.assertEquals(1, map.size());
         // the keys are put in alphabetical order in the maps
         Assertions.assertEquals("[{\"bar\":2,\"foo\":1},{\"bar\":2,\"foo\":1}]", map.get("list.value.path"));
-
-        // can be parsed with gson to the original list
-        Assertions.assertEquals(list, new Gson().fromJson(map.get("list.value.path"), listType));
+        // can be parsed with jakarta to the original list
+        Assertions.assertEquals(list, parsedList);
     }
 
     @Test

--- a/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_02/TypesafeConfigurationTest.java
@@ -45,6 +45,8 @@
  */
 package com.teragrep.cnf_02;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -108,6 +110,8 @@ public class TypesafeConfigurationTest {
 
     @Test
     public void testList() {
+        TypeToken<List<String>> listType = new TypeToken<>() {
+        }; // for gson
         List<String> list = new ArrayList<>();
         list.add("first");
         list.add("second");
@@ -123,7 +127,10 @@ public class TypesafeConfigurationTest {
         Assertions.assertEquals(Arrays.asList("first", "second"), typesafe.getList("listValue").unwrapped());
 
         Assertions.assertEquals(1, map.size());
-        Assertions.assertEquals("[first, second]", map.get("listValue"));
+        Assertions.assertEquals("[\"first\",\"second\"]", map.get("listValue"));
+
+        // can be parsed with gson to the original list
+        Assertions.assertEquals(list, new Gson().fromJson(map.get("listValue"), listType));
     }
 
     @Test
@@ -150,13 +157,16 @@ public class TypesafeConfigurationTest {
 
     @Test
     public void testMapsInList() {
-        Map<String, Object> input1 = new HashMap<>();
+        TypeToken<List<Map<String, Integer>>> listType = new TypeToken<>() {
+        }; // for gson
+
+        Map<String, Integer> input1 = new HashMap<>();
         input1.put("foo", 1);
         input1.put("bar", 2);
-        Map<String, Object> input2 = new HashMap<>();
+        Map<String, Integer> input2 = new HashMap<>();
         input2.put("foo", 1);
         input2.put("bar", 2);
-        List<Object> list = new ArrayList<>();
+        List<Map<String, Integer>> list = new ArrayList<>();
         list.add(input1);
         list.add(input2);
 
@@ -172,7 +182,10 @@ public class TypesafeConfigurationTest {
         // assert the resulting map
         Assertions.assertEquals(1, map.size());
         // the keys are put in alphabetical order in the maps
-        Assertions.assertEquals("[{bar=2, foo=1}, {bar=2, foo=1}]", map.get("list.value.path"));
+        Assertions.assertEquals("[{\"bar\":2,\"foo\":1},{\"bar\":2,\"foo\":1}]", map.get("list.value.path"));
+
+        // can be parsed with gson to the original list
+        Assertions.assertEquals(list, new Gson().fromJson(map.get("list.value.path"), listType));
     }
 
     @Test


### PR DESCRIPTION
Fixes #5 

Lists were represented with the String gotten from List's toString() method. To allow for easier parsing, JSON format is applied instead. Gson library is used for this.

Tests concerning Lists had to be reworked as the results are now different. I added assertions to see that the values can be properly parsed with Gson back to the corresponding Java values as well.